### PR TITLE
update schemaVersion query

### DIFF
--- a/src/main/java/gov/nih/nci/bento_ri/model/PrivateESDataFetcher.java
+++ b/src/main/java/gov/nih/nci/bento_ri/model/PrivateESDataFetcher.java
@@ -28,6 +28,7 @@ import static graphql.schema.idl.TypeRuntimeWiring.newTypeWiring;
 @Component
 public class PrivateESDataFetcher extends AbstractPrivateESDataFetcher {
     private static final Logger logger = LogManager.getLogger(PrivateESDataFetcher.class);
+    private static final String SCHEMA_VERSION = "1.2.0";
     private final YamlQueryFactory yamlQueryFactory;
     private final TypeMapperService typeMapper = new TypeMapperImpl();
 
@@ -82,6 +83,7 @@ public class PrivateESDataFetcher extends AbstractPrivateESDataFetcher {
     public RuntimeWiring buildRuntimeWiring() throws IOException {
         return RuntimeWiring.newRuntimeWiring()
                 .type(newTypeWiring("QueryType")
+                        .dataFetcher("schemaVersion", env -> SCHEMA_VERSION)
                         .dataFetchers(yamlQueryFactory.createYamlQueries(Const.ES_ACCESS_TYPE.PRIVATE))
                         .dataFetcher("searchSubjects", env -> {
                             Map<String, Object> args = env.getArguments();

--- a/src/main/java/gov/nih/nci/bento_ri/model/PublicESDataFetcher.java
+++ b/src/main/java/gov/nih/nci/bento_ri/model/PublicESDataFetcher.java
@@ -17,6 +17,7 @@ import static graphql.schema.idl.TypeRuntimeWiring.newTypeWiring;
 @Component
 public class PublicESDataFetcher extends AbstractPublicESDataFetcher {
     private static final Logger logger = LogManager.getLogger(PublicESDataFetcher.class);
+    private static final String SCHEMA_VERSION = "1.2.0";
     private final YamlQueryFactory yamlQueryFactory;
 
     public PublicESDataFetcher(ESService esService) {
@@ -28,7 +29,7 @@ public class PublicESDataFetcher extends AbstractPublicESDataFetcher {
     public RuntimeWiring buildRuntimeWiring() throws IOException {
         return RuntimeWiring.newRuntimeWiring()
                 .type(newTypeWiring("QueryType")
-                        .dataFetcher("ping", env -> "pong")
+                        .dataFetcher("schemaVersion", env -> SCHEMA_VERSION)
                 )
                 .build();
     }

--- a/src/main/resources/graphql/cds-private-es-schema.graphql
+++ b/src/main/resources/graphql/cds-private-es-schema.graphql
@@ -202,6 +202,7 @@ schema {
 }
 
 type QueryType {
+    schemaVersion: String
     numberOfStudies: Int
     numberOfSubjects: Int
     numberOfSamples: Int

--- a/src/main/resources/graphql/cds-public-es-schema.graphql
+++ b/src/main/resources/graphql/cds-public-es-schema.graphql
@@ -3,5 +3,5 @@ schema {
 }
 
 type QueryType {
-    ping: String
+    schemaVersion: String
 }

--- a/src/main/resources/graphql/cds.graphql
+++ b/src/main/resources/graphql/cds.graphql
@@ -385,8 +385,6 @@ type QueryType {
 		therapeutic_agents: String
     ): [treatment]
 
-    schemaVersion: String @cypher(statement: "RETURN '1.2.0'")
-
     "Get lists of all subject ids, used by Local Find"
     idsLists: IdsLists @cypher(statement: """
         MATCH (p:participant)


### PR DESCRIPTION
- moved private API schemaVersion query to the OpenSearch graphQL schema
- added schemaVersion to the public API as well since it is a separate from the private API and should be versioned separately 